### PR TITLE
Permission and Group Creation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,12 @@
 name: Go
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}"
+        }
+    ]
+}

--- a/internal/authz/store/policy_manager.go
+++ b/internal/authz/store/policy_manager.go
@@ -11,7 +11,7 @@ type PolicyManager[TGroupId any, TPermissionId any, TUserId any] interface {
 	UpdateGroupPermissions(ctx context.Context, groupId TGroupId, permissions []TPermissionId) error
 	UpdateGroupUsers(ctx context.Context, groupId TGroupId, users []TUserId) error
 	UpdateUserGroups(ctx context.Context, userId TUserId, groups []TGroupId) error
-	CreateGroup(ctx context.Context, groupId TGroupId, groupName string) error
+	CreateGroup(ctx context.Context, groupName string) (TGroupId, error)
 	DeleteGroup(ctx context.Context, groupId TGroupId) error
 	ChangeGroupName(ctx context.Context, groupId TGroupId, newGroupName string) error
 	DeleteUser(ctx context.Context, userId TUserId) error

--- a/internal/authz/store/policy_manager.go
+++ b/internal/authz/store/policy_manager.go
@@ -12,6 +12,7 @@ type PolicyManager[TGroupId any, TPermissionId any, TUserId any] interface {
 	UpdateGroupUsers(ctx context.Context, groupId TGroupId, users []TUserId) error
 	UpdateUserGroups(ctx context.Context, userId TUserId, groups []TGroupId) error
 	CreateGroup(ctx context.Context, groupName string) (TGroupId, error)
+	CreatePermission(ctx context.Context, permissionName string) (TPermissionId, error)
 	DeleteGroup(ctx context.Context, groupId TGroupId) error
 	ChangeGroupName(ctx context.Context, groupId TGroupId, newGroupName string) error
 	DeleteUser(ctx context.Context, userId TUserId) error

--- a/internal/authz/store/policy_store_error.go
+++ b/internal/authz/store/policy_store_error.go
@@ -6,7 +6,7 @@ const (
 	DefaultError ErrorCode = iota
 	Concurrency
 	GroupNotFound
-	DuplicateGroupName
+	NameAlreadyExist
 	NoUserRecordsDeleted
 	DatabaseError
 )
@@ -17,7 +17,7 @@ const (
 	defaultErrorDescription         = "An unknown failure has occurred"
 	concurrencyDescription          = "The operation failed due to a concurrency issue"
 	groupNotFoundDescription        = "The group was not found"
-	duplicateGroupNameDescription   = "The group name already exists"
+	nameAlreadyExistsDescription    = "The name already exists"
 	noUserRecordsDeletedDescription = "No user records were deleted"
 	databaseErrorDescription        = "An error occurred while interacting with the database"
 )
@@ -55,10 +55,10 @@ func NewGroupNotFoundError() *PolicyStoreError {
 	}
 }
 
-func NewDuplicateGroupNameError() *PolicyStoreError {
+func NewNameExistsError() *PolicyStoreError {
 	return &PolicyStoreError{
-		Code:        DuplicateGroupName,
-		Description: duplicateGroupNameDescription,
+		Code:        NameAlreadyExist,
+		Description: nameAlreadyExistsDescription,
 	}
 }
 

--- a/internal/authz/store/policy_store_error_test.go
+++ b/internal/authz/store/policy_store_error_test.go
@@ -37,10 +37,10 @@ func TestPolicyStoreError_Error(t *testing.T) {
 		},
 		{
 			name:                "DuplicateGroupNameError",
-			err:                 NewDuplicateGroupNameError(),
-			expectedMsg:         string(duplicateGroupNameDescription),
-			expectedDescription: duplicateGroupNameDescription,
-			expectedCode:        DuplicateGroupName,
+			err:                 NewNameExistsError(),
+			expectedMsg:         string(nameAlreadyExistsDescription),
+			expectedDescription: nameAlreadyExistsDescription,
+			expectedCode:        NameAlreadyExist,
 		},
 		{
 			name:                "NoUserRecordsDeletedError",


### PR DESCRIPTION
- Update GitHub Actions workflow to trigger on pull requests and set permissions.
- Add launch configuration for VS Code.
- Implement CreateGroup method.
- CreateGroup to return group ID and handle unique constraint errors.
- Use a single db interface for all pgx operations.
- Add CreatePermission function.
- Use generic name exists error.